### PR TITLE
fix: remove reference to disabled coverage job in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,9 @@ jobs:
         echo "======================"
         
         if [ "${{ needs.quality-checks.result }}" != "success" ] || \
-           [ "${{ needs.test-matrix.result }}" != "success" ] || \
+           [ "${{ needs.test-matrix.result }}" != "success" ]; then
           #  [ "${{ needs.integration-tests.result }}" != "success" ] || \
-           [ "${{ needs.coverage.result }}" != "success" ]; then
+          #  [ "${{ needs.coverage.result }}" != "success" ]; then
           echo "❌ CI Failed"
           exit 1
         fi


### PR DESCRIPTION
Fix CI workflow by removing reference to disabled coverage job in the status check.

The coverage job is commented out but was still being referenced in the final status check, causing CI to fail.