### PR TITLE
fix: grant GitHub Actions permissions for changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          # This makes the PAT available for pushing
+          token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node.js 20
         uses: actions/setup-node@v4
@@ -38,7 +41,7 @@ jobs:
           commit: "chore: release packages"
           title: "chore: release packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Send a message if a publish happens


### PR DESCRIPTION
## Summary
Fixes the changesets Release workflow by granting necessary permissions and adding optional PAT support.

## Problem
The Release workflow was failing with:
```
remote: Permission to zerothrow/zerothrow.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/zerothrow/zerothrow/': The requested URL returned error: 403
```

## Solution
1. Added explicit permissions to the workflow:
   - `contents: write` - allows pushing commits and creating branches
   - `pull-requests: write` - allows creating version PRs

2. Added optional PAT support:
   - Uses `GH_PAT` if available (enables extra features like triggering other workflows)
   - Falls back to `GITHUB_TOKEN` if not set
   - PAT in checkout step enables pushing to protected branches

## Setup
- Works out of the box with GITHUB_TOKEN
- Optionally add `GH_PAT` secret for enhanced capabilities

🤖 Generated with [Claude Code](https://claude.ai/code)