### PR TITLE
[packages] fix: restore alpha versioning and add missing package files

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,16 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@zerothrow/core": "0.0.2",
+    "@zerothrow/expect": "0.0.1",
+    "@zerothrow/jest": "0.1.1",
+    "@zerothrow/testing": "0.0.1",
+    "@zerothrow/vitest": "0.1.0"
+  },
+  "changesets": [
+    "expect-refactor",
+    "restore-alpha-discipline",
+    "test-packages-alpha"
+  ]
+}

--- a/.changeset/restore-alpha-discipline.md
+++ b/.changeset/restore-alpha-discipline.md
@@ -1,0 +1,13 @@
+---
+"@zerothrow/core": patch
+"@zerothrow/jest": patch
+"@zerothrow/vitest": patch
+"@zerothrow/testing": patch
+"@zerothrow/expect": patch
+---
+
+Restore alpha versioning after accidental stable release
+
+- All packages now properly versioned with -alpha suffix
+- Previous stable versions have been deprecated
+- This ensures users understand these are pre-1.0 packages

--- a/packages/expect/.npmignore
+++ b/packages/expect/.npmignore
@@ -1,0 +1,20 @@
+# Source files
+src/
+test/
+
+# Config files
+tsconfig.json
+tsup.config.ts
+vitest.config.ts
+.turbo/
+
+# Development files
+*.tsbuildinfo
+*.log
+
+# Keep only dist and package files
+!dist/
+!README.md
+!LICENSE
+!CHANGELOG.md
+!package.json

--- a/packages/expect/LICENSE
+++ b/packages/expect/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 J. Kirby Ross
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/testing/.npmignore
+++ b/packages/testing/.npmignore
@@ -1,0 +1,20 @@
+# Source files
+src/
+test/
+
+# Config files
+tsconfig.json
+tsup.config.ts
+vitest.config.ts
+.turbo/
+
+# Development files
+*.tsbuildinfo
+*.log
+
+# Keep only dist and package files
+!dist/
+!README.md
+!LICENSE
+!CHANGELOG.md
+!package.json

--- a/packages/testing/LICENSE
+++ b/packages/testing/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 J. Kirby Ross
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,55 @@
+# @zerothrow/testing
+
+Unified test matchers for ZeroThrow Result types - supports both Jest and Vitest.
+
+## Installation
+
+```bash
+npm install --save-dev @zerothrow/testing
+```
+
+## Usage
+
+This package automatically detects your test environment and loads the appropriate matchers.
+
+### Jest
+
+```typescript
+import '@zerothrow/testing'
+import { ZT } from '@zerothrow/core'
+
+test('user validation', () => {
+  const result = validateUser(input)
+  
+  expect(result).toBeOk()
+  expect(result).toBeOkWith({ name: 'Alice' })
+})
+```
+
+### Vitest
+
+```typescript
+import '@zerothrow/testing'
+import { ZT } from '@zerothrow/core'
+import { expect, test } from 'vitest'
+
+test('user validation', () => {
+  const result = validateUser(input)
+  
+  expect(result).toBeOk()
+  expect(result).toBeOkWith({ name: 'Alice' })
+})
+```
+
+## Available Matchers
+
+- `toBeOk()` - Asserts the Result is Ok
+- `toBeErr()` - Asserts the Result is Err
+- `toBeOkWith(value)` - Asserts Ok with specific value
+- `toBeErrWith(error)` - Asserts Err with specific error
+- `toHaveErrorCode(code)` - Asserts error has specific code (for ZeroError)
+- `toHaveErrorMessage(message)` - Asserts error has specific message
+
+## License
+
+MIT © ZeroThrow

--- a/packages/vitest/.npmignore
+++ b/packages/vitest/.npmignore
@@ -1,0 +1,20 @@
+# Source files
+src/
+test/
+
+# Config files
+tsconfig.json
+tsup.config.ts
+vitest.config.ts
+.turbo/
+
+# Development files
+*.tsbuildinfo
+*.log
+
+# Keep only dist and package files
+!dist/
+!README.md
+!LICENSE
+!CHANGELOG.md
+!package.json


### PR DESCRIPTION
## Summary
- Deprecated accidentally published stable versions on npm
- Configured changesets for prerelease mode with alpha tag
- Added missing LICENSE and README files to packages
- Added .npmignore files to all packages

## Changes
### Version Management
- Deprecated stable versions (0.0.2, 0.1.0, etc.) with messages pointing to alpha versions
- Set up changesets prerelease mode to ensure future releases maintain `-alpha` suffix
- All packages will now publish as `X.Y.Z-alpha.N` format

### Package Completeness
- Added LICENSE to @zerothrow/expect and @zerothrow/testing
- Created README.md for @zerothrow/testing
- Added .npmignore to vitest, expect, and testing packages
- Ensures all published packages have complete metadata

## Next Steps
After merge, we'll need to run `changeset version` and create a release PR to publish the corrected alpha versions.

🤖 Generated with [Claude Code](https://claude.ai/code)