### PR TITLE
fix: make @zerothrow/expect peer dependency flexible

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,8 +63,7 @@
   "license": "MIT",
   "author": "J. Kirby Ross <james@flyingrobots.dev> (https://github.com/flyingrobots)",
   "publishConfig": {
-    "access": "public",
-    "tag": "alpha"
+    "access": "public"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -44,7 +44,7 @@
   "peerDependencies": {
     "@jest/globals": ">=27.0.0",
     "@zerothrow/core": ">=0.1.0",
-    "@zerothrow/expect": "0.1.0",
+    "@zerothrow/expect": ">=0.1.0",
     "jest": ">=27.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@zerothrow/core": ">=0.1.0",
-    "@zerothrow/expect": "0.1.0",
+    "@zerothrow/expect": ">=0.1.0",
     "vitest": ">=0.30.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problems Fixed

### 1. Inflexible peer dependencies
The jest and vitest packages had `@zerothrow/expect` locked to exactly version `0.1.0`, which would require coordinated updates whenever expect needs to be updated.

### 2. Alpha tag in core publishConfig
The core package had `"tag": "alpha"` in its publishConfig, which caused v0.2.0 to be published with the alpha dist-tag instead of latest. This led to dependency resolution issues.

## Solutions

### 1. Flexible peer dependencies
Changed the peer dependency constraint from `"0.1.0"` to `">=0.1.0"` to match the pattern used for other peer dependencies like `@zerothrow/core`.

### 2. Removed alpha tag
Removed the `tag` field from publishConfig in core package.json, so future publishes will default to the `latest` tag.

## Changes
- Updated `packages/jest/package.json` - flexible expect peer dep
- Updated `packages/vitest/package.json` - flexible expect peer dep  
- Updated `packages/core/package.json` - removed alpha tag from publishConfig

These are non-breaking changes that prevent future release issues.