### PR TITLE
[monorepo] chore: bump everything and fix dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,15 +17,15 @@ ZeroThrow is a TypeScript error handling library that replaces exceptions with t
 zerothrow/
 ├── packages/
 │   ├── core/           # Core Result<T,E> type (v0.2.3)
-│   ├── resilience/     # Retry, circuit breaker, timeout (v0.2.0)
-│   ├── jest/           # Jest matchers (v1.1.0)
-│   ├── vitest/         # Vitest matchers (v1.1.0)
-│   ├── testing/        # Unified test package (v1.1.0)
-│   ├── expect/         # Shared matcher logic (v0.2.0)
-│   ├── docker/         # Docker utilities (v0.1.2)
-│   ├── zt-cli/         # CLI tooling (internal)
+│   ├── resilience/     # Retry, circuit breaker, timeout (v0.2.1)
+│   ├── jest/           # Jest matchers (v1.1.1)
+│   ├── vitest/         # Vitest matchers (v1.1.1)
+│   ├── testing/        # Unified test package (v1.1.1)
+│   ├── expect/         # Shared matcher logic (v0.2.1)
+│   ├── docker/         # Docker utilities (v0.1.3)
+│   ├── zt-cli/         # CLI tooling (v0.1.3)
 │   ├── eslint-plugin/  # ESLint rules (unpublished)
-│   └── react/          # React hooks (unpublished)
+│   └── react/          # React hooks (v0.1.1)
 ├── docs-src/           # Source for transcluded documentation
 ├── scripts/            # Build and release scripts
 ├── README.md           # Monorepo control tower

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -6,15 +6,15 @@ Welcome to the **ZeroThrow** ecosystem – a comprehensive suite of packages tha
 
 | Package | Version | Description | Status |
 |---------|---------|-------------|--------|
-| [`@zerothrow/core`](packages/core) | [![npm](https://img.shields.io/npm/v/@zerothrow/core.svg?style=flat-square)](https://npm.im/@zerothrow/core) v0.2.3 | Core ZeroThrow functionality - Rust-style Result<T,E> for TypeScript | ✅ Published |
-| [`@zerothrow/docker`](packages/docker) | [![npm](https://img.shields.io/npm/v/@zerothrow/docker.svg?style=flat-square)](https://npm.im/@zerothrow/docker) v0.1.2 | Zero-throw Docker utilities for testing and container management | ✅ Published |
-| [`@zerothrow/expect`](packages/expect) | [![npm](https://img.shields.io/npm/v/@zerothrow/expect.svg?style=flat-square)](https://npm.im/@zerothrow/expect) v0.2.0 | Shared test matcher logic for ZeroThrow Result types | ✅ Published |
-| [`@zerothrow/jest`](packages/jest) | [![npm](https://img.shields.io/npm/v/@zerothrow/jest.svg?style=flat-square)](https://npm.im/@zerothrow/jest) v1.1.0 | Jest matchers for ZeroThrow Result types | ✅ Published |
-| [`@zerothrow/resilience`](packages/resilience) | [![npm](https://img.shields.io/npm/v/@zerothrow/resilience.svg?style=flat-square)](https://npm.im/@zerothrow/resilience) v0.2.0 | Production-grade resilience patterns for ZeroThrow | ✅ Published |
-| [`@zerothrow/testing`](packages/testing) | [![npm](https://img.shields.io/npm/v/@zerothrow/testing.svg?style=flat-square)](https://npm.im/@zerothrow/testing) v1.1.0 | Unified test matchers for ZeroThrow Result types - supports Jest and Vitest | ✅ Published |
-| [`@zerothrow/vitest`](packages/vitest) | [![npm](https://img.shields.io/npm/v/@zerothrow/vitest.svg?style=flat-square)](https://npm.im/@zerothrow/vitest) v1.1.0 | Vitest matchers for ZeroThrow Result types | ✅ Published |
-| [`@zerothrow/react`](packages/react) | [![npm](https://img.shields.io/badge/npm-v0.1.1-brightgreen)](https://npm.im/@zerothrow/react) v0.1.1 | React hooks and utilities for Result types | ✅ Ready to Publish |
-| [`@zerothrow/zt-cli`](packages/zt-cli) | v0.1.2 | ZeroThrow CLI tool for repo-wide workflows | 🚧 Internal |
+| [`@zerothrow/core`](packages/core) | [![npm](https://img.shields.io/npm/v/@zerothrow/core.svg?style=flat-square)](https://npm.im/@zerothrow/core) | Core ZeroThrow functionality - Rust-style Result<T,E> for TypeScript | ✅ Published |
+| [`@zerothrow/docker`](packages/docker) | [![npm](https://img.shields.io/npm/v/@zerothrow/docker.svg?style=flat-square)](https://npm.im/@zerothrow/docker) | Zero-throw Docker utilities for testing and container management | ✅ Published |
+| [`@zerothrow/expect`](packages/expect) | [![npm](https://img.shields.io/npm/v/@zerothrow/expect.svg?style=flat-square)](https://npm.im/@zerothrow/expect) | Shared test matcher logic for ZeroThrow Result types | ✅ Published |
+| [`@zerothrow/jest`](packages/jest) | [![npm](https://img.shields.io/npm/v/@zerothrow/jest.svg?style=flat-square)](https://npm.im/@zerothrow/jest) | Jest matchers for ZeroThrow Result types | ✅ Published |
+| [`@zerothrow/resilience`](packages/resilience) | [![npm](https://img.shields.io/npm/v/@zerothrow/resilience.svg?style=flat-square)](https://npm.im/@zerothrow/resilience) | Production-grade resilience patterns for ZeroThrow | ✅ Published |
+| [`@zerothrow/testing`](packages/testing) | [![npm](https://img.shields.io/npm/v/@zerothrow/testing.svg?style=flat-square)](https://npm.im/@zerothrow/testing) | Unified test matchers for ZeroThrow Result types - supports Jest and Vitest | ✅ Published |
+| [`@zerothrow/vitest`](packages/vitest) | [![npm](https://img.shields.io/npm/v/@zerothrow/vitest.svg?style=flat-square)](https://npm.im/@zerothrow/vitest) | Vitest matchers for ZeroThrow Result types | ✅ Published |
+| [`@zerothrow/react`](packages/react) | [![npm](https://img.shields.io/npm/v/@zerothrow/react.svg?style=flat-square)](https://npm.im/@zerothrow/react) | React hooks and utilities for Result types | ✅ Published |
+| [`@zerothrow/zt-cli`](packages/zt-cli) | [![npm](https://img.shields.io/npm/v/@zerothrow/zt-cli.svg?style=flat-square)](https://npm.im/@zerothrow/zt-cli) | ZeroThrow CLI tool for repo-wide workflows | ✅ Published |
 
 ## 📦 Unpublished Packages (In Development)
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ All packages live under `/packages` — each folder contains its own README, tes
 | **[@zerothrow/testing](packages/testing)** | ![npm](https://img.shields.io/npm/v/@zerothrow/testing) | Unified test matchers (Jest + Vitest) | 🟢 Beta |
 | **[@zerothrow/expect](packages/expect)** | ![npm](https://img.shields.io/npm/v/@zerothrow/expect) | Shared test matcher logic | 🔧 Internal |
 | **[@zerothrow/docker](packages/docker)** | ![npm](https://img.shields.io/npm/v/@zerothrow/docker) | Docker test utilities | 🟢 Beta |
-| **[@zerothrow/react](packages/react)** | ![npm](https://img.shields.io/badge/npm-v0.1.1-brightgreen) | React hooks and utilities for Result types | 🟢 Beta |
-| **[@zerothrow/zt-cli](packages/zt-cli)** | ![unreleased](https://img.shields.io/badge/npm-unreleased-lightgrey) | CLI tooling | 🔧 Internal |
+| **[@zerothrow/react](packages/react)** | ![npm](https://img.shields.io/npm/v/@zerothrow/react) | React hooks and utilities for Result types | 🟢 Beta |
+| **[@zerothrow/zt-cli](packages/zt-cli)** | ![npm](https://img.shields.io/npm/v/@zerothrow/zt-cli) | CLI tooling | 🟢 Beta |
 
 ### In Development
 

--- a/packages/docker/CHANGELOG.md
+++ b/packages/docker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.3 - 2025-07-07
+
+### Patch Changes
+
+- Fixed workspace protocol dependencies for npm compatibility
+  - Replaced `workspace:*` with actual version numbers in devDependencies
+  - This resolves npm installation issues when packages are published
+
 ## 0.1.2 - 2025-07-07
 
 ### Patch Changes

--- a/packages/docker/package.json
+++ b/packages/docker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerothrow/docker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Zero-throw Docker utilities for testing and container management",
   "type": "module",
   "sideEffects": false,
@@ -47,7 +47,7 @@
     "@zerothrow/core": ">=0.1.0"
   },
   "devDependencies": {
-    "@zerothrow/core": "workspace:*"
+    "@zerothrow/core": "^0.2.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/expect/CHANGELOG.md
+++ b/packages/expect/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @zerothrow/expect
 
+## 0.2.1 - 2025-07-07
+
+### Patch Changes
+
+- Fixed workspace protocol dependencies for npm compatibility
+  - Replaced `workspace:*` with actual version numbers in devDependencies
+  - This resolves npm installation issues when packages are published
+
 ## 0.2.0 - 2025-07-07
 
 ### Minor Changes

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerothrow/expect",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Shared test matcher logic for ZeroThrow Result types",
   "author": "J. Kirby Ross <james@flyingrobots.dev> (https://github.com/flyingrobots)",
   "homepage": "https://github.com/zerothrow/zerothrow#readme",
@@ -55,7 +55,7 @@
     "@zerothrow/core": ">=0.1.0"
   },
   "devDependencies": {
-    "@zerothrow/core": "workspace:*"
+    "@zerothrow/core": "^0.2.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.1 - 2025-07-07
+
+### Patch Changes
+
+- Fixed workspace protocol dependencies for npm compatibility
+  - Replaced `workspace:*` with actual version numbers in devDependencies
+  - This resolves npm installation issues when packages are published
+
 ## 1.1.0 - 2025-07-07
 
 ### Minor Changes

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerothrow/jest",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Jest matchers for ZeroThrow Result types",
   "author": "J. Kirby Ross <james@flyingrobots.dev> (https://github.com/flyingrobots)",
   "license": "MIT",
@@ -53,8 +53,8 @@
     }
   },
   "devDependencies": {
-    "@zerothrow/core": "workspace:*",
-    "@zerothrow/expect": "workspace:*"
+    "@zerothrow/core": "^0.2.3",
+    "@zerothrow/expect": "^0.2.0"
   },
   "keywords": [
     "zerothrow",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Patch Changes
 
+- Fixed workspace protocol dependencies for npm compatibility
+  - Replaced `workspace:*` with actual version numbers in both dependencies and devDependencies
+  - This resolves npm installation issues when packages are published
+  - Now correctly depends on `@zerothrow/core@^0.2.3`
 - Updated dependency on @zerothrow/resilience to ^0.2.0 to support new Policy hierarchy
-- No API changes in this package
 
 ## 0.1.0 - 2025-07-07
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,10 +62,10 @@
     "url": "https://github.com/zerothrow/zerothrow/issues"
   },
   "dependencies": {
-    "@zerothrow/core": "workspace:*"
+    "@zerothrow/core": "^0.2.3"
   },
   "devDependencies": {
-    "@zerothrow/resilience": "workspace:*",
+    "@zerothrow/resilience": "^0.2.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.0.0",

--- a/packages/resilience/CHANGELOG.md
+++ b/packages/resilience/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.1 - 2025-07-07
+
+### Patch Changes
+
+- Fixed workspace protocol dependencies for npm compatibility
+  - Replaced `workspace:*` with actual version numbers in devDependencies
+  - This resolves npm installation issues when packages are published
+
 ## 0.2.0 - 2025-07-07
 
 ### Breaking Changes

--- a/packages/resilience/package.json
+++ b/packages/resilience/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerothrow/resilience",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Production-grade resilience patterns for ZeroThrow",
   "type": "module",
   "sideEffects": false,
@@ -41,7 +41,7 @@
     "@zerothrow/core": ">=0.1.0"
   },
   "devDependencies": {
-    "@zerothrow/core": "workspace:*"
+    "@zerothrow/core": "^0.2.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.1.1 - 2025-07-07
+
+### Patch Changes
+
+- Fixed workspace protocol dependencies for npm compatibility
+  - Replaced `workspace:*` with actual version numbers in regular dependencies
+  - This resolves npm installation issues when packages are published
+  - Now correctly depends on `@zerothrow/jest@^1.1.0` and `@zerothrow/vitest@^1.1.0`
+
 ## 1.1.0 - 2025-07-07
 
 ### Minor Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerothrow/testing",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Unified test matchers for ZeroThrow Result types - supports Jest and Vitest",
   "keywords": [
     "zerothrow",
@@ -34,8 +34,8 @@
     "test": "echo 'Tests run from monorepo root'"
   },
   "dependencies": {
-    "@zerothrow/jest": "workspace:*",
-    "@zerothrow/vitest": "workspace:*"
+    "@zerothrow/jest": "^1.1.0",
+    "@zerothrow/vitest": "^1.1.0"
   },
   "peerDependencies": {
     "@zerothrow/core": ">=0.1.0",

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.1 - 2025-07-07
+
+### Patch Changes
+
+- Fixed workspace protocol dependencies for npm compatibility
+  - Replaced `workspace:*` with actual version numbers in devDependencies
+  - This resolves npm installation issues when packages are published
+
 ## 1.1.0 - 2025-07-07
 
 ### Minor Changes

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerothrow/vitest",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Vitest matchers for ZeroThrow Result types",
   "author": "J. Kirby Ross <james@flyingrobots.dev> (https://github.com/flyingrobots)",
   "homepage": "https://github.com/zerothrow/zerothrow#readme",
@@ -57,8 +57,8 @@
     "vitest": ">=0.30.0"
   },
   "devDependencies": {
-    "@zerothrow/core": "workspace:*",
-    "@zerothrow/expect": "workspace:*"
+    "@zerothrow/core": "^0.2.3",
+    "@zerothrow/expect": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/zt-cli/CHANGELOG.md
+++ b/packages/zt-cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.3 - 2025-07-07
+
+### Patch Changes
+
+- Updated dependencies to latest versions
+  - `@zerothrow/core`: ^0.2.0 → ^0.2.3
+  - `@zerothrow/resilience`: ^0.2.0 → ^0.2.1
+  - Ensures compatibility with latest package versions
+
 ## 0.1.2 - 2025-07-07
 
 ### Patch Changes

--- a/packages/zt-cli/package.json
+++ b/packages/zt-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerothrow/zt-cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "ZeroThrow CLI tool for repo-wide workflows",
   "type": "module",
   "bin": {
@@ -20,8 +20,8 @@
   "author": "J. Kirby Ross <james@flyingrobots.dev> (https://github.com/flyingrobots)",
   "license": "MIT",
   "dependencies": {
-    "@zerothrow/core": "^0.2.0",
-    "@zerothrow/resilience": "^0.2.0",
+    "@zerothrow/core": "^0.2.3",
+    "@zerothrow/resilience": "^0.2.1",
     "chalk": "^5.4.1",
     "commander": "^14.0.0",
     "inquirer": "^12.6.3",


### PR DESCRIPTION
Fixes dependencies between packages -- they were accidentally published with workspace references.