### PR TITLE
[react] Add useResultContext hook for safe context access

### DIFF
--- a/packages/react/DEVELOPER_FEEDBACK.md
+++ b/packages/react/DEVELOPER_FEEDBACK.md
@@ -1,0 +1,115 @@
+# @zerothrow/react Developer Feedback
+
+## Real-World Usage Report
+*Date: 2025-07-07*  
+*Project: purrfect-firs*
+
+### 🎯 What's Working Well
+
+1. **Intuitive API** - Feels natural for React developers
+2. **Automatic Loading States** - No manual state management needed
+3. **Result.match() in JSX** - Clean conditional rendering pattern
+4. **Reduced Boilerplate** - Eliminates loading/error/data state juggling
+
+### 🚀 Feature Roadmap
+
+Based on your feedback, here's what we should build:
+
+#### 1. `useResultContext` Hook
+```tsx
+// Instead of throwing when context is unavailable
+const settingsResult = useResultContext(SettingsContext);
+
+settingsResult.match({
+  ok: (settings) => /* use settings */,
+  err: (error) => /* handle missing provider gracefully */
+});
+```
+
+#### 2. Form Integration Helpers
+```tsx
+const { form, submit, result } = useResultForm({
+  action: myServerAction,
+  onSuccess: (data) => router.push('/success'),
+  validation: zodSchema, // Optional client validation
+});
+```
+
+#### 3. Optimistic Updates
+```tsx
+const { result, loading, optimisticUpdate } = useResult(
+  async () => fetchTodos(),
+  { 
+    optimistic: {
+      addTodo: (current, newTodo) => [...current, newTodo],
+      removeTodo: (current, id) => current.filter(t => t.id !== id)
+    }
+  }
+);
+```
+
+#### 4. Result Persistence
+```tsx
+const { result, loading } = useResult(
+  async () => fetchUserPreferences(),
+  { 
+    persist: 'localStorage',
+    key: 'user-preferences',
+    ttl: 3600000 // 1 hour
+  }
+);
+```
+
+### 📚 Documentation Priorities
+
+1. **Migration Guide**
+   - Converting try/catch patterns
+   - Updating context providers
+   - Handling async operations
+
+2. **Best Practices**
+   - Context provider patterns
+   - Server/client boundary handling
+   - Form error persistence
+
+3. **Integration Examples**
+   - Next.js App Router
+   - React Hook Form
+   - Tanstack Query
+   - SWR
+
+### 🔧 Improvements Needed
+
+1. **Better Error Messages**
+   - Clear warning when ResultBoundary is missing
+   - Helpful hints for common mistakes
+
+2. **DevTools Integration**
+   - Result state inspector
+   - Loading/error timeline
+   - Performance metrics
+
+3. **Type Consistency**
+   - Unified Result types across server/client boundary
+   - Better inference for complex error types
+
+### 🎉 Your "Killer Features" Feedback
+
+These are going in our marketing:
+- "NO MORE UNHANDLED PROMISE REJECTIONS IN COMPONENTS!"
+- "The error handling library React has been waiting for!"
+- "Zero boilerplate"
+- "Type-safe error handling"
+
+### Next Steps
+
+1. Create GitHub issues for each feature request
+2. Start with `useResultContext` (seems most immediately useful)
+3. Build migration guide with real examples
+4. Add form integration examples to docs
+
+Thank you for this incredible feedback! This is exactly what we need to make @zerothrow/react even better. 🚀
+
+---
+
+*P.S. - Glad we fixed that workspace:* issue in v0.1.2! 😅*

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -162,6 +162,42 @@ function App() {
 }
 ```
 
+### Safe Context Access
+
+```tsx
+import { useResultContext, createResultContext } from '@zerothrow/react'
+
+// Using with existing context
+const ThemeContext = createContext<Theme | undefined>(undefined)
+
+function ThemedButton() {
+  const themeResult = useResultContext(ThemeContext)
+  
+  return themeResult.match({
+    ok: (theme) => (
+      <button style={{ background: theme.primary }}>
+        Click me
+      </button>
+    ),
+    err: (error) => (
+      <button>Default Button (no theme)</button>
+    )
+  })
+}
+
+// Creating a Result-based context
+const { Provider, useContext } = createResultContext<UserSettings>('UserSettings')
+
+function SettingsForm() {
+  const settingsResult = useContext()
+  
+  return settingsResult.match({
+    ok: (settings) => <Form initialValues={settings} />,
+    err: () => <Alert>Please configure settings first</Alert>
+  })
+}
+```
+
 ## Core API
 
 ### `useResult`
@@ -218,6 +254,29 @@ interface ResultBoundaryProps {
   fallback: (result: Result<never, Error>, reset: () => void) => ReactNode
   onError?: (error: Error, errorInfo: ErrorInfo) => void
   children: ReactNode
+}
+```
+
+### `useResultContext`
+
+Safe context access that returns Results instead of throwing.
+
+```typescript
+function useResultContext<T>(
+  context: Context<T | undefined | null>,
+  options?: { contextName?: string }
+): Result<T, ContextError>
+```
+
+### `createResultContext`
+
+Helper to create Result-based contexts with companion hooks.
+
+```typescript
+function createResultContext<T>(contextName: string): {
+  Provider: React.Provider<T | undefined>
+  useContext: () => Result<T, ContextError>
+  Context: React.Context<T | undefined>
 }
 ```
 

--- a/packages/react/src/hooks/useResultContext.ts
+++ b/packages/react/src/hooks/useResultContext.ts
@@ -1,0 +1,124 @@
+import { useContext, createContext, type Context } from 'react'
+import { ZT, type Result } from '@zerothrow/core'
+
+export class ContextError extends Error {
+  readonly code = 'CONTEXT_NOT_FOUND' as const
+  readonly contextName: string
+  
+  constructor(contextName: string) {
+    super(`useResultContext: Context "${contextName}" not found. Did you forget to wrap your component in a provider?`)
+    this.name = 'ContextError'
+    this.contextName = contextName
+  }
+}
+
+/**
+ * A Result-based version of React's useContext hook.
+ * 
+ * Instead of throwing when context is not available, this hook returns
+ * a Result that can be pattern matched for safe error handling.
+ * 
+ * @example
+ * ```tsx
+ * const ThemeContext = createContext<Theme | undefined>(undefined)
+ * 
+ * function MyComponent() {
+ *   const themeResult = useResultContext(ThemeContext)
+ *   
+ *   return themeResult.match({
+ *     ok: (theme) => <div style={{ color: theme.primary }}>Themed</div>,
+ *     err: (error) => <div>No theme provider found</div>
+ *   })
+ * }
+ * ```
+ */
+export function useResultContext<T>(
+  context: Context<T | undefined>,
+  options?: {
+    /** Custom context name for better error messages */
+    contextName?: string
+  }
+): Result<T, Error> {
+  const value = useContext(context)
+  
+  if (value === undefined) {
+    const contextName = options?.contextName || context.displayName || 'Unknown'
+    return ZT.err(new ContextError(contextName))
+  }
+  
+  return ZT.ok(value)
+}
+
+/**
+ * A Result-based version of React's useContext hook that handles null values.
+ * 
+ * This variant treats both undefined and null as missing context values.
+ * 
+ * @example
+ * ```tsx
+ * const AuthContext = createContext<User | null>(null)
+ * 
+ * function Profile() {
+ *   const userResult = useResultContextNullable(AuthContext)
+ *   
+ *   return userResult.match({
+ *     ok: (user) => <div>Welcome {user.name}</div>,
+ *     err: () => <div>Please log in</div>
+ *   })
+ * }
+ * ```
+ */
+export function useResultContextNullable<T>(
+  context: Context<T | undefined | null>,
+  options?: {
+    /** Custom context name for better error messages */
+    contextName?: string
+  }
+): Result<T, Error> {
+  const value = useContext(context)
+  
+  if (value === undefined || value === null) {
+    const contextName = options?.contextName || context.displayName || 'Unknown'
+    return ZT.err(new ContextError(contextName))
+  }
+  
+  return ZT.ok(value)
+}
+
+/**
+ * Creates a Result-based context with a companion hook.
+ * 
+ * This helper creates both a Context and a custom hook that uses
+ * useResultContext internally, providing a complete solution for
+ * Result-based context patterns.
+ * 
+ * @example
+ * ```tsx
+ * const { Provider, useContext } = createResultContext<UserSettings>('UserSettings')
+ * 
+ * // In your app
+ * <Provider value={settings}>
+ *   <App />
+ * </Provider>
+ * 
+ * // In a component
+ * function Profile() {
+ *   const settingsResult = useContext()
+ *   
+ *   return settingsResult.match({
+ *     ok: (settings) => <div>{settings.name}</div>,
+ *     err: () => <div>No settings available</div>
+ *   })
+ * }
+ * ```
+ */
+export function createResultContext<T>(contextName: string) {
+  const Context = createContext<T | undefined>(undefined)
+  Context.displayName = contextName
+  
+  return {
+    Provider: Context.Provider,
+    useContext: () => useResultContext(Context, { contextName }),
+    Context
+  }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,10 +6,12 @@
 
 export { useResult } from './hooks/useResult.js'
 export { useResilientResult } from './hooks/useResilientResult.js'
+export { useResultContext, useResultContextNullable, createResultContext } from './hooks/useResultContext.js'
 export { ResultBoundary } from './components/ResultBoundary.js'
 
 export type { UseResultReturn, UseResultOptions } from './hooks/useResult.js'
 export type { UseResilientResultReturn, UseResilientResultOptions } from './hooks/useResilientResult.js'
+export type { ContextError } from './hooks/useResultContext.js'
 export type { ResultBoundaryProps } from './components/ResultBoundary.js'
 
 // Re-export core for convenience

--- a/packages/react/test/useResultContext.test.tsx
+++ b/packages/react/test/useResultContext.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { createContext } from 'react'
+import { useResultContext, useResultContextNullable, createResultContext, ContextError } from '../src/hooks/useResultContext'
+
+describe('useResultContext', () => {
+  it('should return Ok result when context value is available', () => {
+    const TestContext = createContext<string | undefined>('test-value')
+    
+    const { result } = renderHook(() => useResultContext(TestContext))
+    
+    expect(result.current.ok).toBe(true)
+    expect(result.current.value).toBe('test-value')
+  })
+  
+  it('should return Err result when context value is undefined', () => {
+    const TestContext = createContext<string | undefined>(undefined)
+    
+    const { result } = renderHook(() => useResultContext(TestContext))
+    
+    expect(result.current.ok).toBe(false)
+    const error = result.current.error as ContextError
+    expect(error.code).toBe('CONTEXT_NOT_FOUND')
+    expect(error.contextName).toBe('Unknown')
+    expect(error.message).toContain('Unknown')
+  })
+  
+  it('should return Err result when context value is null using nullable version', () => {
+    const TestContext = createContext<string | null>(null)
+    
+    const { result } = renderHook(() => useResultContextNullable(TestContext))
+    
+    expect(result.current.ok).toBe(false)
+    expect((result.current.error as ContextError).code).toBe('CONTEXT_NOT_FOUND')
+  })
+  
+  it('should use custom context name in error', () => {
+    const TestContext = createContext<string | undefined>(undefined)
+    
+    const { result } = renderHook(() => 
+      useResultContext(TestContext, { contextName: 'Theme' })
+    )
+    
+    expect(result.current.ok).toBe(false)
+    const error = result.current.error as ContextError
+    expect(error.code).toBe('CONTEXT_NOT_FOUND')
+    expect(error.contextName).toBe('Theme')
+    expect(error.message).toContain('Theme')
+  })
+  
+  it('should use displayName from context if available', () => {
+    const TestContext = createContext<string | undefined>(undefined)
+    TestContext.displayName = 'TestDisplay'
+    
+    const { result } = renderHook(() => useResultContext(TestContext))
+    
+    expect(result.current.ok).toBe(false)
+    const error = result.current.error as ContextError
+    expect(error.code).toBe('CONTEXT_NOT_FOUND')
+    expect(error.contextName).toBe('TestDisplay')
+  })
+  
+  it('should work with Provider wrapper', () => {
+    const TestContext = createContext<number | undefined>(undefined)
+    
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TestContext.Provider value={42}>
+        {children}
+      </TestContext.Provider>
+    )
+    
+    const { result } = renderHook(() => useResultContext(TestContext), { wrapper })
+    
+    expect(result.current.ok).toBe(true)
+    expect(result.current.value).toBe(42)
+  })
+})
+
+describe('createResultContext', () => {
+  it('should create a working context with Result-based hook', () => {
+    const { Provider, useContext } = createResultContext<string>('TestContext')
+    
+    // Without provider
+    const { result: withoutProvider } = renderHook(() => useContext())
+    expect(!withoutProvider.current.ok).toBe(true)
+    expect((withoutProvider.current.error as ContextError).contextName).toBe('TestContext')
+    
+    // With provider
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <Provider value="hello">
+        {children}
+      </Provider>
+    )
+    
+    const { result: withProvider } = renderHook(() => useContext(), { wrapper })
+    expect(withProvider.current.ok).toBe(true)
+    expect(withProvider.current.value).toBe('hello')
+  })
+  
+  it('should set displayName on created context', () => {
+    const { Context } = createResultContext<number>('MyContext')
+    expect(Context.displayName).toBe('MyContext')
+  })
+})


### PR DESCRIPTION
## Summary

Adds new hooks for safe React Context access that return Results instead of throwing when context is unavailable.

## Features

- **`useResultContext`** - Returns `Result<T, Error>` instead of throwing for missing context
- **`useResultContextNullable`** - Variant that treats both undefined and null as missing
- **`createResultContext`** - Helper to create Result-based contexts with companion hooks

## Motivation

Based on real-world feedback from implementing @zerothrow/react in production:
- When contexts aren't available, we can't throw in Result-based codebases
- Need to handle missing providers gracefully without breaking the Result pattern
- Eliminates the need for "fake" context objects with error Results

## Example

```tsx
const themeResult = useResultContext(ThemeContext)

return themeResult.match({
  ok: (theme) => <div style={{ color: theme.primary }}>Themed</div>,
  err: (error) => <div>No theme provider found</div>
})
```

## Testing

- ✅ All tests passing
- ✅ Full TypeScript support
- ✅ Documentation updated

Closes #39